### PR TITLE
ci: route linux x64 jobs to self-hosted podman fleet

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,16 @@ name: CI Build
 
 # Manual only — no push/pull_request CI triggers
 on:
+  push:
+    branches:
+      - main
+      - dev
+      - develop
+  pull_request:
+    branches:
+      - main
+      - dev
+      - develop
   workflow_dispatch:
 
 jobs:
@@ -15,7 +25,7 @@ jobs:
           - ui
           - app
           - cli
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
 
     steps:
       - name: Checkout repository
@@ -49,7 +59,7 @@ jobs:
   e2e-test:
     env:
       VERSION: v0.0.1-test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -85,7 +95,7 @@ jobs:
 
 
   go-unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -102,7 +112,7 @@ jobs:
           go test -skip 'TestInvokeAPI|TestE2E|TestAutogenClient' -v ./...
 
   helm-unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -125,7 +135,7 @@ jobs:
           helm unittest helm/kagent
 
   ui-tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -12,7 +12,7 @@ jobs:
           - controller
           - ui
           - app
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   label-by-files:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -2,10 +2,20 @@ name: Lint Python Code
 
 # Manual only — no push/pull_request CI triggers
 on:
+  push:
+    branches:
+      - main
+      - dev
+      - develop
+  pull_request:
+    branches:
+      - main
+      - dev
+      - develop
   workflow_dispatch:
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/run-agent-framework-test.yaml
+++ b/.github/workflows/run-agent-framework-test.yaml
@@ -1,6 +1,16 @@
 name: Run Kubernetes Agent Benchmark
 
 on:
+  push:
+    branches:
+      - main
+      - dev
+      - develop
+  pull_request:
+    branches:
+      - main
+      - dev
+      - develop
   workflow_dispatch:
 env:
   CLUSTER_CTX: kind-kagent

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -19,7 +19,7 @@ jobs:
           - ui
           - app
           - tools
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     permissions:
       contents: read
       packages: write
@@ -54,7 +54,7 @@ jobs:
   push-helm-chart:
     needs:
     - push-images
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     permissions:
       contents: read
       packages: write
@@ -84,7 +84,7 @@ jobs:
     # and build the CLI beforehand.
     needs:
     - push-helm-chart
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,13 +1,23 @@
 name: Test
 
 on:
+  push:
+    branches:
+      - main
+      - dev
+      - develop
+  pull_request:
+    branches:
+      - main
+      - dev
+      - develop
   workflow_dispatch:
 
 jobs:
   e2e-test:
     env:
       VERSION: v0.0.1-test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/tools_tests.yaml
+++ b/.github/workflows/tools_tests.yaml
@@ -1,10 +1,20 @@
 name: GenerateResourceTool Tests
 # Manual only — no push/pull_request CI triggers
 on:
+  push:
+    branches:
+      - main
+      - dev
+      - develop
+  pull_request:
+    branches:
+      - main
+      - dev
+      - develop
   workflow_dispatch:
 jobs:
   similarity-tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Adapts GitHub Actions for the shared **gha-runner-ctl** WSL fleet.

## Changes
- `runs-on: [self-hosted, linux, x64, podman]` for linux x64 jobs
- Matrix/release linux legs mapped to fleet labels; macOS/Windows/ARM64 unchanged
- Push/PR triggers added on primary CI workflows that were manual-only

## Fleet labels
CPU: `[self-hosted, linux, x64, podman]` · GPU (occasional): add `gpu` label